### PR TITLE
Changes for Beat Saber 1.40.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ HarmonyPatches/RemoveSplashscreen.cs
 HarmonyPatchHelper.cs
 Screenshots/SocialPreview.jpg
 /.vs
+/.idea

--- a/BetterSongList.csproj
+++ b/BetterSongList.csproj
@@ -114,6 +114,9 @@
     <Reference Include="IPA.Loader">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
     </Reference>
+    <Reference Include="SegmentedControl">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\SegmentedControl.dll</HintPath>
+    </Reference>
     <Reference Include="Unity.TextMeshPro">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
     </Reference>

--- a/Filters/Models/RequirementsFilter.cs
+++ b/Filters/Models/RequirementsFilter.cs
@@ -26,7 +26,7 @@ namespace BetterSongList.FilterModels {
 			if(mid == null)
 				return false;
 
-			return SongCore.Collections.RetrieveExtraSongData(mid)?
+			return SongCore.Collections.GetCustomLevelSongData(mid)?
 				._difficulties?.Any(x => x.additionalDifficultyData._requirements.Any(x => x.Length != 0)) == true;
 		}
 	}

--- a/HarmonyPatches/UI/ExtraLevelParams.cs
+++ b/HarmonyPatches/UI/ExtraLevelParams.cs
@@ -141,7 +141,7 @@ namespace BetterSongList.HarmonyPatches.UI {
 				var basicData = __instance._beatmapLevel.GetDifficultyBeatmapData(beatmapKey.beatmapCharacteristic, beatmapKey.difficulty);
 				var njs = basicData?.noteJumpMovementSpeed ?? 0;
 				if(njs == 0)
-					njs = BeatmapDifficultyMethods.NoteJumpMovementSpeed(beatmapKey.difficulty);
+					njs = beatmapKey.difficulty.DefaultNoteJumpMovementSpeed();
 
 				fields[2].text = njs.ToString("0.0#");
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "gameVersion": "1.37.4",
     "dependsOn": {
         "BSIPA": "^4.3.5",
-        "SongCore": "^3.14.13",
+        "SongCore": "^3.15.1",
         "BeatSaberMarkupLanguage": "^1.12.0"
     },
     "loadBefore": [


### PR DESCRIPTION
- reference `SegmentedControl`
- update obsolete SongCore method and update dependency version
- get NJS from difficulty using `DefaultNoteJumpMovementSpeed()` which return 16 for E+, 12 for E, and 10 for everything else